### PR TITLE
Drop PHP 8.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
     steps:
     - uses: actions/checkout@v4
     - name: Start MySQL

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "composer/installers": "^2.1",
     "drush/drush": "^11.0.5"
   },


### PR DESCRIPTION
Drop PHP 8.0 from CI and require at least PHP 8.1.